### PR TITLE
importのパスにエイリアスを使用できるように設定を見直し

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -351,6 +351,12 @@
         "@types/braces": "*"
       }
     },
+    "@types/node": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.1.tgz",
+      "integrity": "sha512-zyxJM8I1c9q5sRMtVF+zdd13Jt6RU4r4qfhTd7lQubyThvLfx6yYekWSQjGCGV2Tkecgxnlpl/DNlb6Hg+dmEw==",
+      "dev": true
+    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.26.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "vue-router": "^4.0.8"
   },
   "devDependencies": {
+    "@types/node": "^15.12.1",
     "@typescript-eslint/eslint-plugin": "^4.26.0",
     "@typescript-eslint/parser": "^4.26.0",
     "@vitejs/plugin-vue": "^1.2.3",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import { MOCK_ROOMS_DATA } from "./mock/rooms";
+import { MOCK_ROOMS_DATA } from "@/api/mock/rooms";
 
 export const api = {
   showRooms() {

--- a/src/components/rooms/index.vue
+++ b/src/components/rooms/index.vue
@@ -10,8 +10,8 @@
 
 <script lang="ts">
 import { defineComponent, onBeforeMount, reactive } from "vue";
-import { api } from "../../api/index";
-import { Room } from "../../types";
+import { api } from "@/api/index";
+import { Room } from "@/types";
 
 type State = {
   rooms: Room[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from "vue";
-import router from "./router/index";
+import router from "@/router/index";
 
-import App from "./App.vue";
+import App from "@/App.vue";
 
 const app = createApp(App);
 app.use(router);

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,18 +1,18 @@
 import { createRouter, createWebHistory } from "vue-router";
 
-import Top from "../components/top/index.vue";
-import Rooms from "../components/rooms/index.vue";
+import Top from "@/components/top/index.vue";
+import Rooms from "@/components/rooms/index.vue";
 
 const history = createWebHistory();
 
 const routes = [
-	{ path: "/rooms", name: "rooms", component: Rooms },
-	{ path: "/", name: "top", component: Top },
+  { path: "/rooms", name: "rooms", component: Rooms },
+  { path: "/", name: "top", component: Top },
 ];
 
 const router = createRouter({
-	history,
-	routes,
+  history,
+  routes,
 });
 
 export default router;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "node",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
+import { resolve } from "path";
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "/src"),
+    },
+  },
 });


### PR DESCRIPTION
## 変更の概要
- import時のパスの記述を相対パスから絶対パスに変更
- `/src`を`@`で記述できるようにエイリアスを設定

## 備考
- 下記で議論されているように`@`で始まるのではなく`/`で始まるのが推奨されている模様。
`https://github.com/vitejs/vite/issues/279`