### PR TITLE
ユーザー登録ページを作成

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8003,6 +8003,14 @@
         "unzipper": "0.10.11"
       }
     },
+    "vuex": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
+      "integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+      "requires": {
+        "@vue/devtools-api": "^6.0.0-beta.11"
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "vue": "^3.0.5",
-    "vue-router": "^4.0.8"
+    "vue-router": "^4.0.8",
+    "vuex": "^4.0.2"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -41,4 +41,16 @@ export const api = {
       return Promise.reject(null);
     }
   },
+  async fetchUser(userId: string) {
+    const url = "http://localhost:3500/users";
+    const queryParams = new URLSearchParams({ userId });
+    const response = await fetch(`${url}/?${queryParams}`, {
+      method: "GET",
+      headers: {
+        "content-type": "application/json;charset=UTF-8",
+      },
+    });
+    const json = await response.json();
+    return json.data;
+  },
 };

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-import { Room } from "@/types";
+import { Room, User } from "@/types";
 
 export const api = {
   async showRooms(): Promise<Room[]> {
@@ -21,5 +21,24 @@ export const api = {
       },
       body: JSON.stringify({ name }),
     });
+  },
+  async registerUser(name: string): Promise<User | null> {
+    const url = "http://localhost:3500/users";
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json;charset=UTF-8",
+        },
+        body: JSON.stringify({ name }),
+      });
+      const json = await response.json();
+      console.log("ユーザー登録に成功しました。");
+      return json.data;
+    } catch (error) {
+      console.log("ユーザー登録に失敗しました。");
+      console.error(error);
+      return Promise.reject(null);
+    }
   },
 };

--- a/src/components/room/index.vue
+++ b/src/components/room/index.vue
@@ -22,8 +22,10 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, reactive } from "vue";
-import { useRoute } from "vue-router";
+import { api } from "@/api";
+import { defineComponent, onBeforeMount, reactive } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useStore } from "vuex";
 
 type Post = {
   id: number;
@@ -70,6 +72,19 @@ export default defineComponent({
   name: "Room",
   setup() {
     const route = useRoute();
+    const router = useRouter();
+    const store = useStore();
+
+    onBeforeMount(async () => {
+      const userId = localStorage.getItem("USER_ID");
+      if (!userId) return router.push({ name: "user-registration" });
+      if (!store.getters.isUserExist) {
+        const user = await api.fetchUser(userId);
+        user
+          ? store.commit({ type: "set", user })
+          : router.push({ name: "user-registration" });
+      }
+    });
 
     const state = reactive<State>({
       room: { id: route.params.roomId },

--- a/src/components/user-registration/index.vue
+++ b/src/components/user-registration/index.vue
@@ -1,0 +1,81 @@
+<template>
+  <h1>ユーザー登録</h1>
+  <form @submit="submit($event, state)">
+    <label>
+      <p>ユーザー名</p>
+      <div>
+        <input
+          type="text"
+          name="name"
+          v-model="state.form.name"
+          maxlength="8"
+          required
+        />
+      </div>
+    </label>
+    <small>※ ユーザー名は8文字以内で登録可能です。</small>
+    <button type="submit" :disabled="state.isSubmiting" class="submit-button">
+      登録
+    </button>
+  </form>
+  <p v-if="state.hasError" class="error-message">
+    何らかのエラーが発生しました。
+    <br />
+    リロードして再度登録を行うか、時間を置いて再度お試しください。
+  </p>
+  <router-link :to="{ name: 'rooms' }">ルーム一覧</router-link>
+</template>
+
+<script lang="ts">
+import { defineComponent, reactive } from "vue";
+
+import { api } from "@/api/index";
+
+type State = {
+  form: UserForm;
+  isSubmiting: boolean;
+  hasError: boolean;
+};
+
+type UserForm = {
+  name: string;
+};
+
+const submit = async (event: any, state: State) => {
+  event.preventDefault();
+  state.isSubmiting = true;
+  const user = await api.registerUser(state.form.name);
+  if (user) {
+    localStorage.setItem("USER_ID", user.uuid);
+    state.form.name = "";
+  } else {
+    state.hasError = true;
+  }
+  state.isSubmiting = false;
+};
+
+// localstorageにユーザーIDがない場合だけこのページに遷移できる
+export default defineComponent({
+  name: "UserRegistration",
+  setup() {
+    const state = reactive<State>({
+      form: { name: "" },
+      isSubmiting: false,
+      hasError: false,
+    });
+
+    return { state, submit };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.error-message {
+  color: red;
+}
+
+.submit-button {
+  display: table;
+  margin: 0 auto;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { createApp } from "vue";
 import router from "@/router/index";
+import store from "@/store/index";
 
 import App from "@/App.vue";
 
 const app = createApp(App);
 app.use(router);
+app.use(store);
 app.mount("#app");

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,12 +3,18 @@ import { createRouter, createWebHistory } from "vue-router";
 import Top from "@/components/top/index.vue";
 import Rooms from "@/components/rooms/index.vue";
 import Room from "@/components/room/index.vue";
+import UserRegistration from "@/components/user-registration/index.vue";
 
 const history = createWebHistory();
 
 const routes = [
   { path: "/rooms", name: "rooms", component: Rooms },
   { path: "/room/:roomId", name: "room", component: Room },
+  {
+    path: "/user-registration",
+    name: "user-registration",
+    component: UserRegistration,
+  },
   { path: "/", name: "top", component: Top },
 ];
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,7 +9,11 @@ const history = createWebHistory();
 
 const routes = [
   { path: "/rooms", name: "rooms", component: Rooms },
-  { path: "/room/:roomId", name: "room", component: Room },
+  {
+    path: "/room/:roomId",
+    name: "room",
+    component: Room,
+  },
   {
     path: "/user-registration",
     name: "user-registration",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,15 @@
+import { createStore } from "vuex";
+
+import user, { UserState } from "./user";
+
+type RootState = {
+  user: UserState;
+};
+
+const store = createStore<RootState>({
+  modules: {
+    user,
+  },
+});
+
+export default store;

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,0 +1,31 @@
+import { User } from "@/types";
+
+export type UserState = {
+  user: User | null;
+};
+
+const user = {
+  state(): UserState {
+    return { user: null };
+  },
+  mutations: {
+    set(state: UserState, payload: any) {
+      state.user = payload.user;
+    },
+  },
+  actions: {
+    fetch(context: any) {
+      context.commit({ type: "set", user });
+    },
+    register(context: any) {
+      context.commit({ type: "set", user });
+    },
+  },
+  getters: {
+    isUserExist(state: UserState) {
+      return Boolean(state.user);
+    },
+  },
+};
+
+export default user;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,3 +4,9 @@ export type Room = {
   createdAt: string;
   updatedAt: string;
 };
+
+export type User = {
+  id: number;
+  name: string;
+  uuid: string;
+};


### PR DESCRIPTION
## 目的
- ユーザー登録処理を実装するため

## 内容
- [x] Vuexを追加
- [x] ユーザー情報を保持するstoreを作成
- [x] ユーザー情報の取得処理を追加
- [x] ユーザー登録済みかどうかに応じてルームに入室or登録画面に遷移する処理を追加

## 備考
- ロジック
1. localstorageにUSER_IDがない場合ユーザー登録画面に遷移
1. localstorageにUSER_IDがある場合はroomに遷移してuser情報をfetchする(意図的にUSER_IDを書き換えてfetchに失敗した場合は再度ユーザー登録ページに飛ばす)
1. ユーザー登録後及びroomでのuser情報のfetch後ユーザー情報はstoreで保持
1. localstorageを初期化した場合は再度登録が必要になる(前回登録したユーザー情報への復旧はできない)
- VuexをTSに対応させるためInjectionKeyの設定が必要そう