### PR TITLE
ユーザー登録ページ, チャットルームページにアクセス制限を追加

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,10 @@
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, onBeforeMount, reactive } from "vue";
 import { useRoute } from "vue-router";
 import { useStore } from "vuex";
-import { key } from "./store";
+
+import { key } from "@/store";
+import { USER_ACTION } from "@/store/action-types";
 
 export default defineComponent({
   name: "App",
@@ -10,9 +12,20 @@ export default defineComponent({
     const store = useStore(key);
     const route = useRoute();
 
+    const state = reactive<{ isFetched: boolean }>({ isFetched: false });
+
+    onBeforeMount(async () => {
+      const userId = localStorage.getItem("USER_ID");
+      if (userId && !store.getters["user/isUserExist"]) {
+        await store.dispatch(`user/${USER_ACTION.FETCH}`, userId);
+      }
+      state.isFetched = true;
+    });
+
     return {
       userName: computed(() => store.state.user.user?.name || "ゲスト"),
       isTop: computed(() => route.path === "/"),
+      state,
     };
   },
 });
@@ -31,7 +44,7 @@ export default defineComponent({
         Chat App
       </component>
     </component>
-    <p class="text-white text-right leading-8">
+    <p v-show="state.isFetched" class="text-white text-right leading-8">
       {{ "ようこそ " + userName + "さん" }}
     </p>
   </header>

--- a/src/pages/room/index.vue
+++ b/src/pages/room/index.vue
@@ -10,7 +10,7 @@ import {
   nextTick,
   watch,
 } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { useStore } from "vuex";
 import { key } from "@/store";
 
@@ -20,7 +20,6 @@ import ActionCable from "@/lib/actioncable";
 import dayjs from "@/lib/dayjs";
 
 import Button from "@/components/button/index.vue";
-import { USER_MUTATION } from "@/store/mutation-types";
 
 type Post = {
   type: "notification" | "message";
@@ -42,27 +41,12 @@ type State = {
   channel: ActionCable.Channel | null;
 };
 
-const checkValidUser = async () => {
-  const store = useStore(key);
-
-  const userId = localStorage.getItem("USER_ID");
-  if (!userId) return false;
-  if (store.getters["user/isUserExist"]) return true;
-  const user = await api.fetchUser(userId);
-  if (user) {
-    store.commit({ type: `user/${USER_MUTATION.SET}`, user });
-    return true;
-  }
-  return false;
-};
-
 export default defineComponent({
   name: "Room",
   components: {
     Button,
   },
   setup() {
-    const router = useRouter();
     const route = useRoute();
     const store = useStore(key);
     const state = reactive<State>({
@@ -88,10 +72,6 @@ export default defineComponent({
 
     onBeforeMount(async () => {
       const roomId = route.params.roomId;
-      const isValidUser = await checkValidUser();
-      if (!isValidUser) {
-        return router.push({ name: "user-registration" });
-      }
       state.room = await api.fetchRoom(Number(roomId));
 
       const endpoint = "ws:localhost:3500/cable";

--- a/src/pages/room/index.vue
+++ b/src/pages/room/index.vue
@@ -20,6 +20,7 @@ import ActionCable from "@/lib/actioncable";
 import dayjs from "@/lib/dayjs";
 
 import Button from "@/components/button/index.vue";
+import { USER_MUTATION } from "@/store/mutation-types";
 
 type Post = {
   type: "notification" | "message";
@@ -46,10 +47,10 @@ const checkValidUser = async () => {
 
   const userId = localStorage.getItem("USER_ID");
   if (!userId) return false;
-  if (store.getters.isUserExist) return true;
+  if (store.getters["user/isUserExist"]) return true;
   const user = await api.fetchUser(userId);
   if (user) {
-    store.commit({ type: "set", user });
+    store.commit({ type: `user/${USER_MUTATION.SET}`, user });
     return true;
   }
   return false;

--- a/src/pages/top/index.vue
+++ b/src/pages/top/index.vue
@@ -12,7 +12,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="bg-white mx-auto mt-20 py-16 px-20 w-max rounded-lg shadow-sm">
+  <div class="bg-white mx-auto my-20 py-16 px-20 w-max rounded-lg shadow-sm">
     <!-- イラスト：Loose Drawing https://loosedrawing.com/illust/0309/ -->
     <img
       width="500"

--- a/src/pages/user-registration/index.vue
+++ b/src/pages/user-registration/index.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
 import { defineComponent, reactive } from "vue";
 
-import { api } from "@/api/index";
-
 import Button from "@/components/button/index.vue";
 import { useRouter } from "vue-router";
+import { key } from "@/store";
+import { useStore } from "vuex";
+import { USER_ACTION } from "@/store/action-types";
 
 type State = {
   form: UserForm;
@@ -24,6 +25,7 @@ export default defineComponent({
   },
   setup() {
     const router = useRouter();
+    const store = useStore(key);
     const state = reactive<State>({
       form: { name: "" },
       isSubmiting: false,
@@ -33,7 +35,8 @@ export default defineComponent({
     const submit = async (event: Event, state: State) => {
       event.preventDefault();
       state.isSubmiting = true;
-      const user = await api.registerUser(state.form.name);
+      await store.dispatch(`user/${USER_ACTION.REGISTER}`, state.form.name);
+      const user = store.state.user.user;
       if (user) {
         localStorage.setItem("USER_ID", user.uuid);
         state.form.name = "";

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,8 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from "vue-router";
 
+import { store } from "@/store";
+import { USER_ACTION } from "@/store/action-types";
+
 import Top from "@/pages/top/index.vue";
 import Rooms from "@/pages/rooms/index.vue";
 import Room from "@/pages/room/index.vue";
@@ -19,6 +22,15 @@ const routes: RouteRecordRaw[] = [
     path: "/user-registration",
     name: "user-registration",
     component: UserRegistration,
+    beforeEnter: async () => {
+      const userId = localStorage.getItem("USER_ID");
+      if (!userId) return true;
+      if (store.getters["user/isUserExist"]) return false;
+      await store.dispatch(`user/${USER_ACTION.FETCH}`, userId);
+      if (store.getters["user/isUserExist"]) return false;
+
+      return true;
+    },
   },
   { path: "/", name: "top", component: Top },
   { path: "/:pathMatch(.*)*", name: "not-found", component: NotFound },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,25 +11,34 @@ import NotFound from "@/pages/not-found/index.vue";
 
 const history = createWebHistory();
 
+const checkRegisteredUser = async (): Promise<boolean> => {
+  const userId = localStorage.getItem("USER_ID");
+  if (!userId) return false;
+  if (store.getters["user/isUserExist"]) return true;
+  await store.dispatch(`user/${USER_ACTION.FETCH}`, userId);
+  if (store.getters["user/isUserExist"]) return true;
+
+  return false;
+};
+
 const routes: RouteRecordRaw[] = [
   { path: "/rooms", name: "rooms", component: Rooms },
   {
     path: "/room/:roomId",
     name: "room",
     component: Room,
+    beforeEnter: async () => {
+      const isRegistered = await checkRegisteredUser();
+      return isRegistered || { name: "user-registration" };
+    },
   },
   {
     path: "/user-registration",
     name: "user-registration",
     component: UserRegistration,
     beforeEnter: async () => {
-      const userId = localStorage.getItem("USER_ID");
-      if (!userId) return true;
-      if (store.getters["user/isUserExist"]) return false;
-      await store.dispatch(`user/${USER_ACTION.FETCH}`, userId);
-      if (store.getters["user/isUserExist"]) return false;
-
-      return true;
+      const isRegistered = await checkRegisteredUser();
+      return !isRegistered;
     },
   },
   { path: "/", name: "top", component: Top },

--- a/src/store/action-types.ts
+++ b/src/store/action-types.ts
@@ -1,0 +1,3 @@
+export const USER_ACTION = {
+  FETCH: "fetch",
+};

--- a/src/store/action-types.ts
+++ b/src/store/action-types.ts
@@ -1,3 +1,4 @@
 export const USER_ACTION = {
   FETCH: "fetch",
+  REGISTER: "register",
 };

--- a/src/store/mutation-types.ts
+++ b/src/store/mutation-types.ts
@@ -1,0 +1,3 @@
+export const USER_MUTATION = {
+  SET: "set",
+};

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,4 +1,4 @@
-import { ActionContext } from "vuex";
+import { ActionContext, Module } from "vuex";
 
 import { api } from "@/api";
 import { RootState } from "@/store";
@@ -11,7 +11,8 @@ export type UserState = {
   user: User | null;
 };
 
-const user = {
+const user: Module<UserState, RootState> = {
+  namespaced: true,
   state(): UserState {
     return { user: null };
   },
@@ -26,6 +27,13 @@ const user = {
       userId: string
     ) {
       const user = await api.fetchUser(userId);
+      if (user) commit({ type: USER_MUTATION.SET, user });
+    },
+    async [USER_ACTION.REGISTER](
+      { commit }: ActionContext<UserState, RootState>,
+      name: string
+    ) {
+      const user = await api.registerUser(name);
       if (user) commit({ type: USER_MUTATION.SET, user });
     },
   },

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,4 +1,11 @@
+import { ActionContext } from "vuex";
+
+import { api } from "@/api";
+import { RootState } from "@/store";
+
 import { User } from "@/types";
+import { USER_ACTION } from "./action-types";
+import { USER_MUTATION } from "./mutation-types";
 
 export type UserState = {
   user: User | null;
@@ -9,16 +16,17 @@ const user = {
     return { user: null };
   },
   mutations: {
-    set(state: UserState, payload: any) {
+    set(state: UserState, payload: { user: User }) {
       state.user = payload.user;
     },
   },
   actions: {
-    fetch(context: any) {
-      context.commit({ type: "set", user });
-    },
-    register(context: any) {
-      context.commit({ type: "set", user });
+    async [USER_ACTION.FETCH](
+      { commit }: ActionContext<UserState, RootState>,
+      userId: string
+    ) {
+      const user = await api.fetchUser(userId);
+      if (user) commit({ type: USER_MUTATION.SET, user });
     },
   },
   getters: {


### PR DESCRIPTION
## 目的
- ユーザー登録ページにアクセス制限を追加するため

## 変更内容
- [x] userストアの型定義がanyだった箇所に型定義を追加
- [x] userストアの関数名を定数化
- [x] userストアに名前空間を設定、actions, gettersの呼び出し箇所を修正
- [x] ユーザー登録ページへのルーティングにナビゲーションガードを設定
- [x] チャットルームページへのルーティングにナビゲーションガードを設定
- [x] ユーザー情報の読み込みタイミングをサイトへの初回アクセス時に変更

## 備考
- ユーザー登録画面に移行できるのはユーザー登録がされていない時だけ