### PR TITLE
フォームのスタイルがiOSだと崩れる不具合を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",
-    "serve": "vite preview",
+    "serve": "vite preview --port 3000",
     "test:unit": "jest",
     "format": "prettier src/*.{ts,vue} src/**/*.{ts,vue}",
     "lint": "eslint src/*.{ts,vue} src/**/*.{ts,vue}"

--- a/src/pages/room/index.vue
+++ b/src/pages/room/index.vue
@@ -191,13 +191,13 @@ export default defineComponent({
           class="
             mb-4
             input
-            ring-2 ring-gray-300
+            border-2 border-gray-300
             rounded
             w-full
             py-2
             px-4
             resize-none
-            focus:outline-none focus:ring-2 focus:ring-blue-600
+            focus:outline-none focus:border-2 focus:border-blue-600
           "
         ></textarea>
         <Button type="submit" class="mx-auto">送信</Button>

--- a/src/pages/rooms/index.vue
+++ b/src/pages/rooms/index.vue
@@ -116,11 +116,11 @@ export default defineComponent({
                   :maxlength="10"
                   class="
                     input
-                    ring-2 ring-gray-300
+                    border-2 border-gray-300
                     rounded
                     w-full
                     block
-                    focus:outline-none focus:ring-2 focus:ring-blue-600
+                    focus:outline-none focus:border-2 focus:border-blue-600
                     mb-4
                     py-2
                     px-4

--- a/src/pages/user-registration/index.vue
+++ b/src/pages/user-registration/index.vue
@@ -67,11 +67,11 @@ export default defineComponent({
             required
             class="
               input
-              ring-2 ring-gray-300
+              border-2 border-gray-300
               rounded
               w-full
               block
-              focus:outline-none focus:ring-2 focus:ring-blue-600
+              focus:outline-none focus:border-2 focus:border-blue-600
               mb-4
               py-2
               px-4


### PR DESCRIPTION
## 目的
- フォームのスタイルがiOSだと崩れる不具合を修正するため

## 備考
- ビルドしてiOSで見た時にringだと枠線が消えていた。
- ringではなくborderで設定した方が良さそうだった
- vite previewで起動するサーバーのポート番号を開発時と合わせて3000にした。