### PR TITLE
apiのurlを環境変数に定義

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,4 @@
+NODE_ENV=development
+
+VITE_API_ORIGIN=http://localhost:3500
+VITE_API_CABLE_URL=ws:localhost:3500/cable

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "version": "0.0.0",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --mode development",
     "build": "vue-tsc --noEmit && vite build",
     "serve": "vite preview --port 3000",
     "test:unit": "jest",

--- a/src/pages/room/index.vue
+++ b/src/pages/room/index.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       const roomId = route.params.roomId;
       state.room = await api.fetchRoom(Number(roomId));
 
-      const endpoint = "ws:localhost:3500/cable";
+      const endpoint = import.meta.env.VITE_API_CABLE_URL;
       const cable = ActionCable.createConsumer(endpoint);
       state.channel = cable.subscriptions.create(
         {

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,4 +1,4 @@
-interface ImportMetaEnv extends Readonly<Record<string, string>> {
+interface ImportMetaEnv {
   readonly VITE_API_ORIGIN: string;
   readonly VITE_API_CABLE_URL: string;
 }

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,0 +1,9 @@
+interface ImportMetaEnv extends Readonly<Record<string, string>> {
+  readonly VITE_API_ORIGIN: string;
+  readonly VITE_API_CABLE_URL: string;
+}
+
+// eslint-disable-next-line no-unused-vars
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -2,7 +2,7 @@ async function wrappedFetch(
   path: string,
   option: RequestInit
 ): Promise<Response> {
-  const ORIGIN = "http://localhost:3500";
+  const ORIGIN = import.meta.env.VITE_API_ORIGIN;
   const CONTENT_TYPE = "application/json;charset=UTF-8";
   const response = await fetch(`${ORIGIN}${path}`, {
     headers: {


### PR DESCRIPTION
## 目的
- apiのurlを環境変数に定義するため

## 備考
- 機密情報は含まないため.envファイルはcommitするものとして判断した。
- 参考
https://ja.vitejs.dev/guide/env-and-mode.html#intellisense
- ↑でエラーが出たため下記を参考に修正
https://github.com/vitejs/vite/issues/3524#issuecomment-846941145